### PR TITLE
Fix tests for most recent version of vows allowed by package.json

### DIFF
--- a/test/pkginfo-test.js
+++ b/test/pkginfo-test.js
@@ -13,7 +13,7 @@ var assert = require('assert'),
     pkginfo = require('../lib/pkginfo');
 
 function assertProperties (source, target) {
-  assert.length(source, target.length + 1);
+  assert.lengthOf(source, target.length + 1);
   target.forEach(function (prop) {
     assert.isTrue(!!~source.indexOf(prop));
   });


### PR DESCRIPTION
This is causing any dependent modules to fail when the npm npat config flag is set to true (e.g. anything which depends on winston)

Thanks,

Raoul
