### PR TITLE
Tweaked `pkginfo.find` behaviour

### DIFF
--- a/examples/subdir/package.json
+++ b/examples/subdir/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "simple-app-subdir",
+  "description": "A test fixture for pkginfo",
+  "version": "0.1.0",
+  "author": "Charlie Robbins <charlie.robbins@gmail.com>",
+  "keywords": ["test", "fixture"],
+  "main": "./index.js",
+  "scripts": { "test": "vows test/*-test.js --spec" },
+  "engines": { "node": ">= 0.4.0" },
+  "subdironly": "true"
+}

--- a/examples/target-dir.js
+++ b/examples/target-dir.js
@@ -1,0 +1,20 @@
+/*
+ * multiple-properties.js: Sample of including multiple properties from a package.json file
+ *
+ * (C) 2011, Charlie Robbins
+ *
+ */
+ 
+var util = require('util'),
+    path = require('path'),
+    pkginfo = require('../lib/pkginfo')(module, { dir: path.resolve(__dirname, 'subdir' )});
+
+exports.someFunction = function () {
+  console.log('some of your custom logic here');
+};
+
+console.log('Inspecting module:');
+console.dir(module.exports);
+
+console.log('\nAll exports exposed:');
+console.error(Object.keys(module.exports));

--- a/lib/pkginfo.js
+++ b/lib/pkginfo.js
@@ -52,7 +52,10 @@ var pkginfo = module.exports = function (pmodule, options) {
   //
   // **Setup default options**
   //
-  options = options || { include: [] };
+  options = options || {};
+  
+  // ensure that includes have been defined
+  options.include = options.include || [];
   
   if (args.length > 0) {
     //
@@ -85,8 +88,9 @@ var pkginfo = module.exports = function (pmodule, options) {
 // which contains a `package.json` file. 
 //
 pkginfo.find = function (pmodule, dir) {
-  dir = dir || pmodule.filename;
-  dir = path.dirname(dir); 
+  if (! dir) {
+    dir = path.dirname(pmodule.filename);
+  }
   
   var files = fs.readdirSync(dir);
   
@@ -101,7 +105,7 @@ pkginfo.find = function (pmodule, dir) {
     throw new Error('Cannot find package.json from unspecified directory');
   }
   
-  return pkginfo.find(pmodule, dir);
+  return pkginfo.find(pmodule, path.dirname(dir));
 };
 
 //

--- a/test/pkginfo-test.js
+++ b/test/pkginfo-test.js
@@ -19,6 +19,21 @@ function assertProperties (source, target) {
   });
 }
 
+function compareWithExample(targetPath) {
+  var examplePaths = ['package.json'];
+  
+  if (targetPath) {
+    examplePaths.unshift(targetPath);
+  }
+  
+  return function(exposed) {
+    var pkg = fs.readFileSync(path.join.apply(null, [__dirname, '..', 'examples'].concat(examplePaths))).toString(),
+        keys = Object.keys(JSON.parse(pkg));
+    
+    assertProperties(exposed, keys);
+  };
+}
+
 function testExposes (options) {
   return {
     topic: function () {
@@ -56,14 +71,13 @@ vows.describe('pkginfo').addBatch({
       script: 'array-argument.js',
       properties: ['version', 'author']
     }),
+    "and read from a specified directory": testExposes({
+      script: 'target-dir.js',
+      assert: compareWithExample('subdir')
+    }),
     "and passed no arguments": testExposes({
       script: 'all-properties.js',
-      assert: function (exposed) {
-        var pkg = fs.readFileSync(path.join(__dirname, '..', 'examples', 'package.json')).toString(),
-            keys = Object.keys(JSON.parse(pkg));
-        
-        assertProperties(exposed, keys);
-      }
+      assert: compareWithExample()
     })
   }
 }).export(module);


### PR DESCRIPTION
This is a small change which allows the `pkginfo.find` method to work correctly when using the `dir` option.

From inspecting the code I noticed the dir option but when I tried to use it pkginfo would fail. In the first instance it failed because it was always firing `path.dirname` on the supplied directory.  While this is right behaviour when extracting the directory from the module.filename it does mean the directory that was initially specified is skipped in the search.

After implementing this functionality, I wrote a test to ensure the functionality was working correctly and noticed that no defaults for the `includes` option were specified if I provided the `dir` option, so this has been adjusted as well.

If I've missed anything, then please let me know and I'll be happy to fix it up appropriately.

Cheers,
Damon.
