### PR TITLE
Small README update on npm installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,8 @@ An easy way to expose properties on a module from a package.json
 ## Installation
 
 ### Installing npm (node package manager)
-```
-  curl http://npmjs.org/install.sh | sh
-```
+
+`npm` now comes with [Node.js](http://nodejs.org/).
 
 ### Installing pkginfo
 ```


### PR DESCRIPTION
Node.js now comes with npm by default; no need to run a special command to install it anymore.