### PR TITLE
allowing pkginfo function to return the package, exports might sometimes already exist

### DIFF
--- a/lib/pkginfo.js
+++ b/lib/pkginfo.js
@@ -77,7 +77,7 @@ var pkginfo = module.exports = function (pmodule, options) {
     }
   });
   
-  return pkginfo;
+  return pkg;
 };
 
 //


### PR DESCRIPTION
for example

``` json
// package.json
{ "name": "myapp" }
```

``` javascript
module.exports = { name: 'abc' }
require('pkginfo')(module);
// this is going to filter out package.json#name
//instead, with this version, instead of returning pkginfo, it returns the pkg, which allows this
var pkg = require('pkginfo')(module);
assert(pkg.name === "myapp");
```
