### PR TITLE
Add file extension for browserify compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {
     "vows": "0.7.x"
   },
-  "main": "./lib/pkginfo",
+  "main": "./lib/pkginfo.js",
   "scripts": { "test": "vows test/*-test.js --spec" },
   "engines": { "node": ">= 0.4.0" }
 }


### PR DESCRIPTION
Fails to browserify without the .js extension for the entry point. Found this when attempting to browserify winston.