### PR TITLE
Use require instead of readDir/readFile for Meteor 1.3 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ If you're looking for further usage see the [examples][0] included in this repos
 Tests are written in [vows][1] and give complete coverage of all APIs.
 
 ```
-  vows test/*-test.js --spec
+  npm install
+  npm test
 ```
 
 [0]: https://github.com/indexzero/node-pkginfo/tree/master/examples

--- a/lib/pkginfo.js
+++ b/lib/pkginfo.js
@@ -5,8 +5,7 @@
  *
  */
 
-var fs = require('fs'),
-    path = require('path');
+var path = require('path');
 
 //
 // ### function pkginfo ([options, 'property', 'property' ..])

--- a/lib/pkginfo.js
+++ b/lib/pkginfo.js
@@ -4,7 +4,7 @@
  * (C) 2011, Charlie Robbins
  *
  */
- 
+
 var fs = require('fs'),
     path = require('path');
 
@@ -13,7 +13,7 @@ var fs = require('fs'),
 // #### @pmodule {Module} Parent module to read from.
 // #### @options {Object|Array|string} **Optional** Options used when exposing properties.
 // #### @arguments {string...} **Optional** Specified properties to expose.
-// Exposes properties from the package.json file for the parent module on 
+// Exposes properties from the package.json file for the parent module on
 // it's exports. Valid usage:
 //
 // `require('pkginfo')()`
@@ -28,7 +28,7 @@ var pkginfo = module.exports = function (pmodule, options) {
   var args = [].slice.call(arguments, 2).filter(function (arg) {
     return typeof arg === 'string';
   });
-  
+
   //
   // **Parse variable arguments**
   //
@@ -48,35 +48,35 @@ var pkginfo = module.exports = function (pmodule, options) {
     //
     options = { include: [options] };
   }
-  
+
   //
   // **Setup default options**
   //
   options = options || {};
-  
+
   // ensure that includes have been defined
   options.include = options.include || [];
-  
+
   if (args.length > 0) {
     //
     // If additional string arguments have been passed in
-    // then add them to the properties to expose on the 
-    // parent module. 
+    // then add them to the properties to expose on the
+    // parent module.
     //
     options.include = options.include.concat(args);
   }
-  
+
   var pkg = pkginfo.read(pmodule, options.dir).package;
   Object.keys(pkg).forEach(function (key) {
     if (options.include.length > 0 && !~options.include.indexOf(key)) {
       return;
     }
-    
+
     if (!pmodule.exports[key]) {
       pmodule.exports[key] = pkg[key];
     }
   });
-  
+
   return pkginfo;
 };
 
@@ -85,26 +85,27 @@ var pkginfo = module.exports = function (pmodule, options) {
 // #### @pmodule {Module} Parent module to read from.
 // #### @dir {string} **Optional** Directory to start search from.
 // Searches up the directory tree from `dir` until it finds a directory
-// which contains a `package.json` file. 
+// which contains a `package.json` file.
 //
 pkginfo.find = function (pmodule, dir) {
   if (! dir) {
-    dir = path.dirname(pmodule.filename);
+    dir = path.dirname(pmodule.filename || pmodule.id);
   }
-  
-  var files = fs.readdirSync(dir);
-  
-  if (~files.indexOf('package.json')) {
-    return path.join(dir, 'package.json');
-  }
-  
+
   if (dir === '/') {
-    throw new Error('Could not find package.json up from: ' + dir);
+    throw new Error('Could not find package.json up from /');
   }
   else if (!dir || dir === '.') {
     throw new Error('Cannot find package.json from unspecified directory');
   }
-  
+
+  var contents;
+  try {
+    contents = require(dir + '/package.json');
+  } catch (error) {}
+
+  if (contents) return contents;
+
   return pkginfo.find(pmodule, path.dirname(dir));
 };
 
@@ -115,14 +116,10 @@ pkginfo.find = function (pmodule, dir) {
 // Searches up the directory tree from `dir` until it finds a directory
 // which contains a `package.json` file and returns the package information.
 //
-pkginfo.read = function (pmodule, dir) { 
-  dir = pkginfo.find(pmodule, dir);
-  
-  var data = fs.readFileSync(dir).toString();
-      
+pkginfo.read = function (pmodule, dir) {
   return {
-    dir: dir, 
-    package: JSON.parse(data)
+    dir: dir,
+    package: pkginfo.find(pmodule, dir),
   };
 };
 

--- a/lib/pkginfo.js
+++ b/lib/pkginfo.js
@@ -93,7 +93,8 @@ pkginfo.find = function (pmodule, dir) {
   }
 
   if (dir === '/') {
-    throw new Error('Could not find package.json up from /');
+    throw new Error('Could not find package.json up from ' +
+                (pmodule.filename || pmodule.id));
   }
   else if (!dir || dir === '.') {
     throw new Error('Cannot find package.json from unspecified directory');


### PR DESCRIPTION
You can find a description of why this is necessary here: https://github.com/meteor/meteor/issues/6313#issuecomment-188371347

Existing tests still pass. It might be nice to add one or two tests for the cases this is fixing, but I'm not sure how to replicate outside of a Meteor 1.3 app.