### PR TITLE
limit recursive dir lookup

### DIFF
--- a/lib/pkginfo.js
+++ b/lib/pkginfo.js
@@ -106,7 +106,11 @@ pkginfo.find = function (pmodule, dir) {
 
   if (contents) return contents;
 
-  return pkginfo.find(pmodule, path.dirname(dir));
+  if (dir !== path.dirname(dir)) {
+    return pkginfo.find(pmodule, path.dirname(dir));
+  } else {
+    return {};
+  }
 };
 
 //


### PR DESCRIPTION
when using pkg to package a script which uses pkginfo through args i discovered that it was possible that pkginfo ran into an infinite loop. this is because of the way require is implemented in pkg (https://github.com/zeit/pkg). to allow for this i made this small change which supposedly does not change how pkginfo works. all tests are green. i hope this is fine for you.