### PR TITLE
Use `path.dirname` to more safely check for the root directory of the filesystem across platforms

### DIFF
--- a/lib/pkginfo.js
+++ b/lib/pkginfo.js
@@ -91,7 +91,7 @@ pkginfo.find = function (pmodule, dir) {
     dir = path.dirname(pmodule.filename || pmodule.id);
   }
 
-  if (dir === '/') {
+  if (dir === path.dirname(dir)) {
     throw new Error('Could not find package.json up from ' +
                 (pmodule.filename || pmodule.id));
   }


### PR DESCRIPTION
Supersedes #22. cc/ @dotob